### PR TITLE
Prevent syntax error when PROMPT_COMMAND not empty

### DIFF
--- a/bash_sessions
+++ b/bash_sessions
@@ -145,7 +145,7 @@ fi
 # switch to working directory
 if [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd" ]; then
 	cd "$(cat "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd")"
-	export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_savepwd"
+	export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }__bs_savepwd"
 fi
 
 # load environment
@@ -156,7 +156,7 @@ if [[ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_changed" || -f "${BASH_S
 	while read line; do
 		unset $line;
 	done < "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_deleted"
-	export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_saveenv"
+	export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }__bs_saveenv"
 fi
 
 '  > "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/bashrc"
@@ -342,12 +342,12 @@ S (){
 	elif [ "${1}" == "pwd" ]; then
 		if [ "${2}" == "on" ]; then
 			if ! [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd" ]; then
-				export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_savepwd"
+				export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }__bs_savepwd"
 			fi
 		elif [ "${2}" == "off" ]; then
 			if [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd" ]; then
 				rm "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd"
-				export PROMPT_COMMAND="${PROMPT_COMMAND/;__bs_savepwd/}"
+				export PROMPT_COMMAND="${PROMPT_COMMAND/; __bs_savepwd/}"
 			fi
 		else
 			echo "bash_sessions: invalid argument \"${2}\""
@@ -356,7 +356,7 @@ S (){
 	elif [ "${1}" == "env" ]; then
 		if [ "${2}" == "on" ]; then
 			if ! [[ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_changed" && -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_deleted" ]]; then
-				export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_saveenv"
+				export PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }__bs_saveenv"
 			fi
 		elif [ "${2}" == "off" ]; then
 			if [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_changed" ]; then
@@ -365,7 +365,7 @@ S (){
 			if [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_deleted" ]; then
 				rm "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_deleted"
 			fi
-			export PROMPT_COMMAND="${PROMPT_COMMAND/;__bs_saveenv/}"
+			export PROMPT_COMMAND="${PROMPT_COMMAND/; __bs_saveenv/}"
 		else
 			echo "bash_sessions: invalid argument \"${2}\""
 		fi

--- a/bash_sessions
+++ b/bash_sessions
@@ -156,7 +156,7 @@ if [[ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_changed" || -f "${BASH_S
 	while read line; do
 		unset $line;
 	done < "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_deleted"
-	export PROMPT_COMMAND="${PROMPT_COMMAND};__bs_saveenv"
+	export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_saveenv"
 fi
 
 '  > "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/bashrc"
@@ -342,7 +342,7 @@ S (){
 	elif [ "${1}" == "pwd" ]; then
 		if [ "${2}" == "on" ]; then
 			if ! [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd" ]; then
-				export PROMPT_COMMAND="${PROMPT_COMMAND};__bs_savepwd"
+				export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_savepwd"
 			fi
 		elif [ "${2}" == "off" ]; then
 			if [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/pwd" ]; then
@@ -356,7 +356,7 @@ S (){
 	elif [ "${1}" == "env" ]; then
 		if [ "${2}" == "on" ]; then
 			if ! [[ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_changed" && -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_deleted" ]]; then
-				export PROMPT_COMMAND="${PROMPT_COMMAND};__bs_saveenv"
+				export PROMPT_COMMAND="${PROMPT_COMMAND:+;}__bs_saveenv"
 			fi
 		elif [ "${2}" == "off" ]; then
 			if [ -f "${BASH_SESSIONS_DIR}/${BASH_SESSION_NAME}/env_changed" ]; then


### PR DESCRIPTION
Having the PROMPT_COMMAND variable already set led to the script setting the variable to ;__save... which resulted in unexpected token ; syntax error